### PR TITLE
Add switch handler with read/write support and tests

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
@@ -10,11 +10,13 @@ from .light_handler import LightHandler
 from .climate_handler import ClimateHandler
 from .generic_handler import GenericHandler
 from .fan_handler import FanHandler
+from .switch_handler import SwitchHandler
 
 __all__ = [
     "BaseHandler",
     "LightHandler",
     "ClimateHandler",
     "GenericHandler",
-    "FanHandler"
+    "FanHandler",
+    "SwitchHandler" 
 ]

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py
@@ -1,0 +1,28 @@
+from .base_handler import BaseHandler
+
+
+class SwitchHandler(BaseHandler):
+
+    def handle_write(self, api_client, register, value):
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            if value == 1:
+                api_client.call_service("switch", "turn_on", {"entity_id": entity_id})
+            elif value == 0:
+                api_client.call_service("switch", "turn_off", {"entity_id": entity_id})
+            else:
+                raise ValueError("Switch state must be 0 or 1")
+
+        else:
+            raise ValueError(f"Unsupported switch attribute: {entity_point}")
+
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            return 1 if state == "on" else 0
+
+        return entity_data.get("attributes", {}).get(entity_point, 0)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -34,7 +34,7 @@ import logging
 import requests
 from requests import get
 
-from .handlers import LightHandler, ClimateHandler, GenericHandler, FanHandler
+from .handlers import LightHandler, ClimateHandler, GenericHandler, FanHandler, SwitchHandler
 from .api_client import HomeAssistantAPIClient
 
 _log = logging.getLogger(__name__)
@@ -50,6 +50,7 @@ service_mapping= {
     "climate": ClimateHandler(),
     "input_boolean": GenericHandler(),
     "fan": FanHandler(),
+    "switch": SwitchHandler(),
 }
 
 class HomeAssistantRegister(BaseRegister):

--- a/services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py
+++ b/services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*- {{{
+# ===----------------------------------------------------------------------===
+#
+# Component of Eclipse VOLTTRON
+#
+# ===----------------------------------------------------------------------===
+#
+# Copyright 2023 Battelle Memorial Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# ===----------------------------------------------------------------------===
+# }}}
+
+from unittest.mock import Mock
+
+import pytest
+
+from platform_driver.interfaces.handlers.switch_handler import SwitchHandler
+
+
+class _Register:
+    def __init__(self, entity_id, entity_point):
+        self.entity_id = entity_id
+        self.entity_point = entity_point
+
+
+@pytest.fixture
+def switch_handler():
+    return SwitchHandler()
+
+
+@pytest.fixture
+def api_client():
+    return Mock()
+
+
+@pytest.mark.parametrize("value,service", [(1, "turn_on"), (0, "turn_off")])
+def test_handle_write_state_calls_expected_service(switch_handler, api_client, value, service):
+    register = _Register("switch.living_room_outlet", "state")
+
+    switch_handler.handle_write(api_client, register, value)
+
+    api_client.call_service.assert_called_once_with("switch", service, {"entity_id": "switch.living_room_outlet"})
+
+
+@pytest.mark.parametrize("value", [2, -1, "on", "invalid", None])
+def test_handle_write_state_rejects_invalid_values(switch_handler, api_client, value):
+    register = _Register("switch.living_room_outlet", "state")
+
+    with pytest.raises(ValueError, match="Switch state must be 0 or 1"):
+        switch_handler.handle_write(api_client, register, value)
+
+
+def test_handle_write_rejects_unsupported_entity_point(switch_handler, api_client):
+    register = _Register("switch.living_room_outlet", "power_consumption")
+
+    with pytest.raises(ValueError, match="Unsupported switch attribute"):
+        switch_handler.handle_write(api_client, register, 1)
+
+
+@pytest.mark.parametrize("state,expected", [("on", 1), ("off", 0), ("unknown", 0), (None, 0)])
+def test_handle_read_state_maps_to_int(switch_handler, state, expected):
+    register = _Register("switch.living_room_outlet", "state")
+    entity_data = {"state": state, "attributes": {}}
+
+    assert switch_handler.handle_read(entity_data, register) == expected
+
+
+def test_handle_read_fallback_to_attribute_value(switch_handler):
+    register = _Register("switch.living_room_outlet", "friendly_name")
+    entity_data = {"state": "on", "attributes": {"friendly_name": "Living Room Outlet"}}
+
+    assert switch_handler.handle_read(entity_data, register) == "Living Room Outlet"


### PR DESCRIPTION
Closes #20

## Changes

1. Add [`switch_handler.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py)
   - New `SwitchHandler(BaseHandler)` class
   - Write support: `0/1` → `switch.turn_off` / `switch.turn_on`
   - Read support: `"on"/"off"` → `1/0`
   - Raises `ValueError` for invalid state values or unsupported entity points

2. Update [`handlers/__init__.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py)
   - Import and export `SwitchHandler`

3. Update [`home_assistant.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py)
   - Add `SwitchHandler` to import
   - Register `"switch": SwitchHandler()` in `service_mapping`

4. Add [`test_home_assistant_switch_handler.py`](services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py)
   - 13 unit tests covering write, read, and error cases
   - Uses `Mock` for `api_client` — no live HA instance required

## Test Results
```
13 passed, 0 failed
```