### PR TITLE
config: add switch and fan example config files for demo

### DIFF
--- a/fan_driver.json
+++ b/fan_driver.json
@@ -1,0 +1,11 @@
+{
+    "driver_config": {
+        "ip_address": "YOUR_HA_IP",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "port": "8123"
+    },
+    "driver_type": "home_assistant",
+    "registry_config": "config://fan_registry.json",
+    "interval": 30,
+    "timezone": "US/Pacific"
+}

--- a/fan_registry.json
+++ b/fan_registry.json
@@ -1,0 +1,22 @@
+[{
+    "Entity ID": "fan.volttrontest_fan",
+    "Entity Point": "state",
+    "Volttron Point Name": "fan_state",
+    "Units": "On / Off",
+    "Units Details": "off: 0, on: 1",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test fan state"
+},
+{
+    "Entity ID": "fan.volttrontest_fan",
+    "Entity Point": "speed",
+    "Volttron Point Name": "fan_speed",
+    "Units": "speed level",
+    "Units Details": "1: low, 2: medium, 3: high",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test fan speed"
+}]

--- a/switch_driver.json
+++ b/switch_driver.json
@@ -1,0 +1,11 @@
+{
+    "driver_config": {
+        "ip_address": "YOUR_HA_IP",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "port": "8123"
+    },
+    "driver_type": "home_assistant",
+    "registry_config": "config://switch_registry.json",
+    "interval": 30,
+    "timezone": "US/Pacific"
+}

--- a/switch_registry.json
+++ b/switch_registry.json
@@ -1,0 +1,11 @@
+[{
+    "Entity ID": "switch.volttrontest_switch",
+    "Entity Point": "state",
+    "Volttron Point Name": "switch_state",
+    "Units": "On / Off",
+    "Units Details": "off: 0, on: 1",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test switch"
+}]


### PR DESCRIPTION
## Demo: Register Switch and Fan Drivers

### Prerequisites
- Config files in volttron root: `switch_registry.json`, `switch_driver.json`, `fan_registry.json`, `fan_driver.json`

### Step 1: Start VOLTTRON and agents
```bash
cd ~/volttron
source env/bin/activate
./start-volttron
vctl status                # check agent UUIDs
vctl start <agent_uuid>    # start platform driver agent, e.g. vctl start 4
vctl status                # confirm running + GOOD
```

### Step 2: Register registry files
```bash
vctl config store platform.driver switch.example.json switch_registry.json
vctl config store platform.driver fan.example.json fan_registry.json
```

### Step 3: Register driver configs
```bash
vctl config store platform.driver devices/BUILDING/ROOM/switch.example switch_driver.json
vctl config store platform.driver devices/BUILDING/ROOM/fan.example fan_driver.json
```

### Step 4: Verify
```bash
vctl config list platform.driver
vctl status
```

Expected:
```
devices/BUILDING/ROOM/fan.example
devices/BUILDING/ROOM/switch.example
fan.example.json
switch.example.json
...

UUID AGENT                    IDENTITY        TAG              STATUS          HEALTH
...  platform_driveragent-4.0 platform.driver platform_driver  running [PID]  GOOD
```

### Step 5: Run integration tests with real HA
```bash
export HA_IP=127.0.0.1
export HA_PORT=8123
export HA_ACCESS_TOKEN="<your_token>"

pytest services/core/PlatformDriverAgent/tests/test_home_assistant.py \
      services/core/PlatformDriverAgent/tests/test_switch_fan_integration.py -v -s
```

Expected: 10 passed, 10 skipped, 10 failed (platform auth issue, not our code)