### PR TITLE
Add demo config files for light and climate

### DIFF
--- a/climate_driver.json
+++ b/climate_driver.json
@@ -1,0 +1,11 @@
+{
+    "driver_config": {
+        "ip_address": "YOUR_HA_IP",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "port": "8123"
+    },
+    "driver_type": "home_assistant",
+    "registry_config": "config://climate.example.json",
+    "interval": 30,
+    "timezone": "US/Pacific"
+}

--- a/climate_registry.json
+++ b/climate_registry.json
@@ -1,0 +1,22 @@
+[{
+    "Entity ID": "climate.volttrontest_thermostat",
+    "Entity Point": "state",
+    "Volttron Point Name": "climate_state",
+    "Units": "mode",
+    "Units Details": "off: 0, heat: 2, cool: 3, auto: 4",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test climate state"
+},
+{
+    "Entity ID": "climate.volttrontest_thermostat",
+    "Entity Point": "temperature",
+    "Volttron Point Name": "climate_temperature",
+    "Units": "degrees",
+    "Units Details": "target temperature",
+    "Writable": true,
+    "Starting Value": 70,
+    "Type": "float",
+    "Notes": "test climate temperature"
+}]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -238,11 +238,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/3.10':
-    None,
-    'volttron-ansible':
-    ('https://volttron.readthedocs.io/projects/volttron-ansible/en/main/',
-     None)
+    'python': ('https://docs.python.org/3.10', None),
+    'volttron-ansible': ('https://volttron.readthedocs.io/projects/volttron-ansible/en/main/', None)
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/light_driver.json
+++ b/light_driver.json
@@ -1,0 +1,11 @@
+{
+    "driver_config": {
+        "ip_address": "YOUR_HA_IP",
+        "access_token": "YOUR_ACCESS_TOKEN",
+        "port": "8123"
+    },
+    "driver_type": "home_assistant",
+    "registry_config": "config://light_registry.json",
+    "interval": 30,
+    "timezone": "US/Pacific"
+}

--- a/light_registry.json
+++ b/light_registry.json
@@ -1,0 +1,22 @@
+[{
+    "Entity ID": "light.volttrontest_light",
+    "Entity Point": "state",
+    "Volttron Point Name": "light_state",
+    "Units": "On / Off",
+    "Units Details": "off: 0, on: 1",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test light state"
+},
+{
+    "Entity ID": "light.volttrontest_light",
+    "Entity Point": "brightness",
+    "Volttron Point Name": "light_brightness",
+    "Units": "int",
+    "Units Details": "0-255",
+    "Writable": true,
+    "Starting Value": 0,
+    "Type": "int",
+    "Notes": "test light brightness"
+}]


### PR DESCRIPTION
## Overview
Added example config and registry files for light and climate devices 
to support demo of existing HomeAssistant Driver functionality.

## Files Added
- `light_driver.json`, `light_registry.json` — example config for light
- `climate_driver.json`, `climate_registry.json` — example config for climate
- Fixed `docs/source/conf.py` intersphinx_mapping configuration